### PR TITLE
feat: add creator credit to footer with localization support in Engli…

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,6 +4,8 @@ import Icon from "./Icon.astro";
 interface Props { t: Translation }
 const { t } = Astro.props;
 const year = new Date().getFullYear();
+const creatorName = "Mateo";
+const creatorCreditParts = t.footer.creatorCredit.split("{name}");
 ---
 
 <footer class="site-footer">
@@ -11,5 +13,12 @@ const year = new Date().getFullYear();
 		<div class="footer-brand"><Icon name="qr" /><span>QRGenerator</span></div>
 		<p>{t.footer.localProcessing}</p>
 		<p>{t.footer.copyright.replace("{year}", String(year))}</p>
+		<p>
+			{creatorCreditParts[0]}
+			<a href="https://mateobetancur.com" target="_blank" rel="noreferrer">
+				{creatorName}
+			</a>
+			{creatorCreditParts[1] ?? ""}
+		</p>
 	</div>
 </footer>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -92,5 +92,6 @@ export const en: Translation = {
 	footer: {
 		copyright: "© {year} QRGenerator",
 		localProcessing: "QR codes generated locally in your browser",
+		creatorCredit: "Created by {name}",
 	},
 };

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -96,5 +96,6 @@ export const es: Translation = {
 	footer: {
 		copyright: "© {year} QRGenerator",
 		localProcessing: "Códigos QR generados localmente en tu navegador",
+		creatorCredit: "Creado por {name}",
 	},
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -80,5 +80,6 @@ export interface Translation {
 	footer: {
 		copyright: string;
 		localProcessing: string;
+		creatorCredit: string;
 	};
 }


### PR DESCRIPTION
This pull request adds a creator credit line to the site footer, supporting internationalization for both English and Spanish. The credit includes a link to the creator's website and is fully localized using the translation system.

Footer enhancement:

* Added a new creator credit line in the `Footer.astro` component, displaying "Created by Mateo" (or the localized equivalent) with a link to https://mateobetancur.com. The text is split to allow for proper localization and placement of the creator's name.

Internationalization updates:

* Added a new `creatorCredit` entry to the `footer` section of the translation files for both English (`"Created by {name}"`) and Spanish (`"Creado por {name}"`). [[1]](diffhunk://#diff-5d3a6cad982bab6401d067a9ce59dc96f6449d1872222058ab91b48bb00b6929R95) [[2]](diffhunk://#diff-68837a516b9d2dd41c65b8dea62911586ab0c5f044aebbb743d988e1edb21e7dR99)
* Updated the `Translation` interface to include the new `creatorCredit` field in the `footer` object.…sh and Spanish